### PR TITLE
Add methods to customize the keypad fonts

### DIFF
--- a/Classes/MMNumberKeyboard.h
+++ b/Classes/MMNumberKeyboard.h
@@ -138,4 +138,18 @@ typedef NS_ENUM(NSUInteger, MMNumberKeyboardButtonStyle) {
  */
 @property (assign, nonatomic) MMNumberKeyboardButtonStyle returnKeyButtonStyle;
 
+/**
+ *  The font used for the return key button.
+ *
+ *  @note The default value is the system font of size 17.
+ */
+@property (nonatomic) UIFont *returnKeyFont;
+
+/**
+ *  The font used for the numbers and separators.
+ *
+ *  @note The default value is the system font (light) of size 28.
+ */
+@property (nonatomic) UIFont *keypadFont;
+
 @end

--- a/Classes/MMNumberKeyboard.m
+++ b/Classes/MMNumberKeyboard.m
@@ -424,6 +424,32 @@ static const CGFloat MMNumberKeyboardPadSpacing = 8.0f;
     }
 }
 
+- (void)setReturnKeyFont:(UIFont *)returnKeyFont
+{
+    if ([_returnKeyFont isEqual:returnKeyFont]) {
+        return;
+    }
+
+    _returnKeyFont = returnKeyFont;
+
+    _MMNumberKeyboardButton *button = self.buttonDictionary[@(MMNumberKeyboardButtonDone)];
+    [button.titleLabel setFont:returnKeyFont];
+}
+
+- (void)setKeypadFont:(UIFont *)keypadFont
+{
+    if ([_keypadFont isEqual:keypadFont]) {
+        return;
+    }
+
+    _keypadFont = keypadFont;
+
+    for (MMNumberKeyboardButton key = MMNumberKeyboardButtonNumberMin; key < MMNumberKeyboardButtonNumberMax; key++) {
+        _MMNumberKeyboardButton *button = self.buttonDictionary[@(key)];
+        [button.titleLabel setFont:keypadFont];
+    }
+}
+
 #pragma mark - Layout.
 
 NS_INLINE CGRect MMButtonRectMake(CGRect rect, CGRect contentRect, UIUserInterfaceIdiom interfaceIdiom){


### PR DESCRIPTION
UIAppearance methods do not seem to work on devices when the view is presented as UIInputView.